### PR TITLE
Don't set the storage account name for now

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "azurerm_app_service" "wwt" {
   
   app_settings = {
     "UseAzurePlateFiles" = "true"
-    "AzurePlateFileStorageAccount" = azurerm_storage_account.datatier.primary_blob_endpoint
+    #"AzurePlateFileStorageAccount" = azurerm_storage_account.datatier.primary_blob_endpoint
     "KeyVaultName" = azurerm_key_vault.wwt.name
   }
 


### PR DESCRIPTION
We are currently not using the storage account but a connection string from keyvault. By putting it here, it ends up being used and no blobs are available. Once we move the storage account to ARM we can switch to managed identity and re-enable it here.