### PR TITLE
App Service w/DockerHub container example

### DIFF
--- a/api/main.tf
+++ b/api/main.tf
@@ -1,0 +1,38 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "main" {
+  name     = "${var.prefix}-resources"
+  location = var.location
+}
+
+resource "azurerm_app_service_plan" "main" {
+  name                = "${var.prefix}-ctr-plan"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  kind                = "Linux"
+  reserved            = true
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "main" {
+  name                = "${var.prefix}-ctr-web"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  app_service_plan_id = azurerm_app_service_plan.main.id
+
+  site_config {
+    app_command_line = ""
+    linux_fx_version = "DOCKER|appsvcsample/python-helloworld:latest"
+  }
+
+  app_settings = {
+    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
+    "DOCKER_REGISTRY_SERVER_URL"          = "https://index.docker.io"
+  }
+}

--- a/api/outputs.tf
+++ b/api/outputs.tf
@@ -1,0 +1,7 @@
+output "app_service_name" {
+  value = azurerm_app_service.main.name
+}
+
+output "app_service_default_hostname" {
+  value = "https://${azurerm_app_service.main.default_site_hostname}"
+}

--- a/api/variables.tf
+++ b/api/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  description = "The prefix used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure location where all resources in this example should be created"
+}


### PR DESCRIPTION
Example contains an App Service Plan (Linux) set to S1 and creates a Web App on it using a container image from DockerHub.

To make this real, we need to push the .NET 5 app to a container on DockerHub and set all of the App Settings that the app depends upon as we have done in the current App Service.  Setting the App Insights instrumentation key App Setting will allow the container version to continue to feed into the same App Insights instance we have been using.

@pkgw - this should only be considered an example - please re-visit the naming of resources per a convention you prefer.