### PR TITLE
Wire up staging slot for the MVC5 app

### DIFF
--- a/website/main.tf
+++ b/website/main.tf
@@ -301,12 +301,15 @@ resource "azurerm_app_service" "wwt" {
   }
 
   app_settings = {
-    "UseAzurePlateFiles" = "true"
-    "UseCaching" = "true"
+    "APPINSIGHTS_INSTRUMENTATIONKEY" = azurerm_application_insights.wwt.instrumentation_key
     #"AzurePlateFileStorageAccount" = azurerm_storage_account.datatier.primary_blob_endpoint
     "KeyVaultName" = azurerm_key_vault.wwt.name
+    "LiveClientId" = var.liveClientId
+    "LiveClientRedirectUrlMap" = var.liveClientRedirectUrlMap
+    "LiveClientSecret" = var.liveClientSecret
     "SlidingExpiration" = "30.00:00:00" # default to 30 days to keep cached items
-    "APPINSIGHTS_INSTRUMENTATIONKEY" = azurerm_application_insights.wwt.instrumentation_key
+    "UseAzurePlateFiles" = "true"
+    "UseCaching" = "true"
   }
 
   identity {
@@ -314,11 +317,38 @@ resource "azurerm_app_service" "wwt" {
   }
 }
 
+resource "azurerm_app_service_slot" "communities_stage" {
+  name                = "stage"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  app_service_plan_id = azurerm_app_service_plan.wwt.id
+  app_service_name    = azurerm_app_service.wwt.name
+
+  site_config {
+    always_on = false
+    dotnet_framework_version = "v4.0"
+  }
+
+  app_settings = azurerm_app_service.wwt.app_settings
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+
 # Here, too, this policy is called just "appservice" but it is now specifically
 # for the Windows-based Communities service.
 resource "azurerm_key_vault_access_policy" "appservice" {
   key_vault_id            = azurerm_key_vault.wwt.id
   tenant_id               = data.azurerm_client_config.current.tenant_id
   object_id               = azurerm_app_service.wwt.identity.0.principal_id
+  secret_permissions      = ["get", "list"]
+}
+
+resource "azurerm_key_vault_access_policy" "appservice_stage" {
+  key_vault_id            = azurerm_key_vault.wwt.id
+  tenant_id               = data.azurerm_client_config.current.tenant_id
+  object_id               = azurerm_app_service_slot.communities_stage.identity.0.principal_id
   secret_permissions      = ["get", "list"]
 }

--- a/website/variables.tf
+++ b/website/variables.tf
@@ -5,3 +5,15 @@ variable "prefix" {
 variable "location" {
   description = "The location where resources will be created"
 }
+
+variable "liveClientId" {
+  description = "The ID of the Microsoft Live OAuth app"
+}
+
+variable "liveClientRedirectUrlMap" {
+  description = "A map from server hostname to OAuth redirectURL to use"
+}
+
+variable "liveClientSecret" {
+  description = "The OAuth app secret"
+}


### PR DESCRIPTION
The new resources in the Terraform config already existed in practice — we’re just importing them into the config now.

I'm now a bit unclear as to how ASP.Net app settings interact with deployment slot swaps. You can specify settings as slot-specific, which would imply that when you do a swap the setting changes. My initial efforts convinced me that this wasn't actually working as I expected, and now there are several more points to consider:

- We had an undetected deployment bug in our pipelines that would have affected my testing
- It is not 100% clear to me that Terraform properly understands deployment slot swaps ([reference](https://github.com/terraform-providers/terraform-provider-azurerm/issues/2005))
- I don't know if there's a way to mark app settings as slot-specific inside Terraform

For now, I'm taking the approach that app settings have to stay fixed between "stage" and "production" slots, but maybe we don't need to be so restrictive in general.