### PR TITLE
website: use AzureRM backend to store state in the cloud

### DIFF
--- a/website/main.tf
+++ b/website/main.tf
@@ -6,6 +6,17 @@ provider "azurerm" {
   features {}
 }
 
+# Store state in WWT's Azure blob storage:
+
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "devops-support"
+    storage_account_name = "wwtdevops"
+    container_name       = "terraform-state"
+    key                  = "prod.terraform.tfstate"
+  }
+}
+
 # Main resource group. For now, all of the resources in this file can sensibly
 # share the same lifecycle, so it makes sense to put them all into one big
 # resource group.


### PR DESCRIPTION
I'm not seeing a way to allow for different backend options, so that one could use a local state storage backend for testing, or a different storage account for a dev environment. Seems like there ought to be a way to do that? But in the meantime, we definitely want our production state to be stored in the cloud.