### PR TITLE
Set up the Constellations superuser setting

### DIFF
--- a/dev/constellations-backend.tf
+++ b/dev/constellations-backend.tf
@@ -47,6 +47,7 @@ resource "azurerm_linux_web_app" "cx_backend" {
 
   app_settings = {
     "AZURE_COSMOS_CONNECTIONSTRING" = azurerm_cosmosdb_account.cx_backend.connection_strings[0]
+    "KEYCLOAK_URL"                  = "https://${var.tld}/auth/"
   }
 
   site_config {

--- a/dev/constellations-backend.tf
+++ b/dev/constellations-backend.tf
@@ -47,6 +47,7 @@ resource "azurerm_linux_web_app" "cx_backend" {
 
   app_settings = {
     "AZURE_COSMOS_CONNECTIONSTRING" = azurerm_cosmosdb_account.cx_backend.connection_strings[0]
+    "CX_SUPERUSER_ACCOUNT_ID"       = var.superuserAccountId
     "KEYCLOAK_URL"                  = "https://${var.tld}/auth/"
   }
 

--- a/dev/variables.tf
+++ b/dev/variables.tf
@@ -33,3 +33,10 @@ variable "gatewaySslCertSecretId" {
   # This cert is managed outside of Terraform through keyvault-acmebot:
   description = "The Keyvault ID of the SSL certificate to use for the App Gateway frontend"
 }
+
+variable "superuserAccountId" {
+  # I can't see how it would be a problem if this value leaked somehow, but just
+  # to be safe we mark it as sensitive.
+  description = "The account ID of an account with special admin privileges"
+  sensitive   = true
+}


### PR DESCRIPTION
We have a new setting coded at server-launch time that can hardcode a specific account with the ability to perform certain low-level administrative actions. If the setting is missing or some kind of dummy value, no one will be superuser.